### PR TITLE
Adding model folder in the docker image for API process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,21 +19,24 @@ RUN apt-get update && apt-get install -y \
 #      Tensorflow version (attention: won't run on Apple Silicon)
 # FROM tensorflow/tensorflow:2.16.1
 
+# Copy and install requirements
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir -r requirements.txt
+
 # Copy everything we need into the image
 COPY deepsign deepsign
 COPY api api
-COPY requirements.txt requirements.txt
+COPY models models
 COPY setup.py setup.py
 # COPY credentials.json credentials.json
 
-# Install everything
-RUN pip install --no-cache-dir --upgrade pip
-RUN pip install --no-cache-dir -r requirements.txt
+# Install package
 RUN pip install .
 
 # Make directories that we need, but that are not included in the COPY
 RUN mkdir /raw_data
-RUN mkdir /models
+# RUN mkdir /models
 
 # TODO: to speed up, you can load your model from MLFlow or Google Cloud Storage at startup using
 # RUN python -c 'replace_this_with_the_commands_you_need_to_run_to_load_the_model'


### PR DESCRIPTION
- Moved `COPY` and `RUN pip install` for requirements on the beginning of the script to push to cache and accelerate future builds
- Added `COPY` of models folder to be used by API
- Commented `RUN mkdir /models` as no longer needed 